### PR TITLE
Add drag-and-drop MIDI controller editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MIDI Controller Editor</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="app">
+    <div id="palette"></div>
+    <div id="workspace" class="grid"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,151 @@
+const cellSize = 60;
+const workspaceCols = 12;
+const workspaceRows = 6;
+const moduleRows = 2;
+const moduleCols = 4;
+
+const moduleDefs = {
+  pot: { label: 'Potentiometer', cellClass: 'pot' },
+  encoder: { label: 'Encoder', cellClass: 'encoder' },
+  button: { label: 'Button', cellClass: 'button' },
+  slider: { label: 'Slider', cellClass: 'slider' }
+};
+
+const occupancy = Array.from({ length: workspaceRows }, () => Array(workspaceCols).fill(null));
+let moduleCounter = 0;
+
+const palette = document.getElementById('palette');
+const workspace = document.getElementById('workspace');
+
+function createModuleElement(type) {
+  const def = moduleDefs[type];
+  const mod = document.createElement('div');
+  mod.className = 'module';
+  mod.dataset.type = type;
+  for (let i = 0; i < moduleRows * moduleCols; i++) {
+    const cell = document.createElement('div');
+    cell.className = 'cell';
+    const comp = document.createElement('div');
+    comp.className = 'component ' + def.cellClass;
+    cell.appendChild(comp);
+    mod.appendChild(cell);
+  }
+  return mod;
+}
+
+function initPalette() {
+  Object.keys(moduleDefs).forEach(type => {
+    const tmpl = createModuleElement(type);
+    tmpl.classList.add('template');
+    tmpl.draggable = true;
+    tmpl.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('type', type);
+    });
+    palette.appendChild(tmpl);
+  });
+}
+
+function occupy(x, y, id) {
+  for (let r = 0; r < moduleRows; r++) {
+    for (let c = 0; c < moduleCols; c++) {
+      occupancy[y + r][x + c] = id;
+    }
+  }
+}
+
+function clearOccupancy(id, x, y) {
+  for (let r = 0; r < moduleRows; r++) {
+    for (let c = 0; c < moduleCols; c++) {
+      if (occupancy[y + r][x + c] === id) {
+        occupancy[y + r][x + c] = null;
+      }
+    }
+  }
+}
+
+function canPlace(x, y, ignoreId = null) {
+  if (x < 0 || y < 0 || x + moduleCols > workspaceCols || y + moduleRows > workspaceRows) {
+    return false;
+  }
+  for (let r = 0; r < moduleRows; r++) {
+    for (let c = 0; c < moduleCols; c++) {
+      const occ = occupancy[y + r][x + c];
+      if (occ && occ !== ignoreId) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function addWorkspaceModule(type, x, y) {
+  const mod = createModuleElement(type);
+  mod.classList.add('placed');
+  const id = 'm' + moduleCounter++;
+  mod.dataset.id = id;
+  mod.style.left = x * cellSize + 'px';
+  mod.style.top = y * cellSize + 'px';
+  mod.dataset.gridX = x;
+  mod.dataset.gridY = y;
+
+  const del = document.createElement('button');
+  del.textContent = '×';
+  del.className = 'delete';
+  del.addEventListener('click', () => removeModule(mod));
+  mod.appendChild(del);
+
+  mod.draggable = true;
+  mod.addEventListener('dragstart', e => {
+    e.dataTransfer.setData('moduleId', id);
+    const rect = mod.getBoundingClientRect();
+    e.dataTransfer.setData('offsetX', e.clientX - rect.left);
+    e.dataTransfer.setData('offsetY', e.clientY - rect.top);
+  });
+
+  workspace.appendChild(mod);
+  occupy(x, y, id);
+}
+
+function removeModule(mod) {
+  const id = mod.dataset.id;
+  const x = parseInt(mod.dataset.gridX, 10);
+  const y = parseInt(mod.dataset.gridY, 10);
+  clearOccupancy(id, x, y);
+  mod.remove();
+}
+
+workspace.addEventListener('dragover', e => e.preventDefault());
+
+workspace.addEventListener('drop', e => {
+  e.preventDefault();
+  const rect = workspace.getBoundingClientRect();
+  const offsetX = parseInt(e.dataTransfer.getData('offsetX')) || 0;
+  const offsetY = parseInt(e.dataTransfer.getData('offsetY')) || 0;
+  let x = Math.floor((e.clientX - rect.left - offsetX) / cellSize + 0.5);
+  let y = Math.floor((e.clientY - rect.top - offsetY) / cellSize + 0.5);
+
+  const moduleId = e.dataTransfer.getData('moduleId');
+  if (moduleId) {
+    const mod = document.querySelector(`[data-id="${moduleId}"]`);
+    const oldX = parseInt(mod.dataset.gridX, 10);
+    const oldY = parseInt(mod.dataset.gridY, 10);
+    clearOccupancy(moduleId, oldX, oldY);
+    if (canPlace(x, y, moduleId)) {
+      mod.style.left = x * cellSize + 'px';
+      mod.style.top = y * cellSize + 'px';
+      mod.dataset.gridX = x;
+      mod.dataset.gridY = y;
+      occupy(x, y, moduleId);
+    } else {
+      occupy(oldX, oldY, moduleId);
+    }
+    return;
+  }
+
+  const type = e.dataTransfer.getData('type');
+  if (type && canPlace(x, y)) {
+    addWorkspaceModule(type, x, y);
+  }
+});
+
+initPalette();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,116 @@
+:root {
+  --cell: 60px;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+#app {
+  display: flex;
+  gap: 20px;
+}
+
+#palette {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.module {
+  width: calc(var(--cell) * 4);
+  height: calc(var(--cell) * 2);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  position: relative;
+  user-select: none;
+}
+
+.cell {
+  width: var(--cell);
+  height: var(--cell);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.component {
+  pointer-events: none;
+}
+
+.component.pot {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #aaa;
+  position: relative;
+}
+.component.pot::after {
+  content: '';
+  position: absolute;
+  width: 4px;
+  height: 20px;
+  background: #333;
+  top: 5px;
+  left: 50%;
+  margin-left: -2px;
+}
+
+.component.encoder {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 4px solid #555;
+  background: #eee;
+}
+
+.component.button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #c00;
+}
+
+.component.slider {
+  width: 10px;
+  height: 40px;
+  border-radius: 5px;
+  background: #333;
+}
+
+#workspace {
+  position: relative;
+  width: calc(var(--cell) * 12);
+  height: calc(var(--cell) * 6);
+  background-image:
+    linear-gradient(to right, #ccc 1px, transparent 1px),
+    linear-gradient(to bottom, #ccc 1px, transparent 1px);
+  background-size: var(--cell) var(--cell);
+}
+
+.module .delete {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 50%;
+  background: #f33;
+  color: #fff;
+  font-weight: bold;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+
+.template {
+  cursor: grab;
+}
+
+.placed {
+  position: absolute;
+  cursor: grab;
+}


### PR DESCRIPTION
## Summary
- Create basic static app for modular MIDI controller layout
- Support four module types (potentiometer, encoder, button, slider) in a palette
- Allow modules to be dragged, snapped to grid, moved, and deleted on a workspace

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976b92a110832a94ca0c9bd5403a15